### PR TITLE
Allow for skipping SSL validation when downloading fly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Flyenv
 
-If you need to work with multiple [Concourse](https://concourse-ci.org/) instances running on different version, 
+If you need to work with multiple [Concourse](https://concourse-ci.org/) instances running on different version,
 you must have run `fly -t <target> sync` a couple times when you jumping back and forth between those instances.
 
 flyenv could be **the** solution.
@@ -24,7 +24,7 @@ $ fly -t c580 curl /api/v1/info
 $ fly -t c571 --version # "-flyenv" suffix is added to differentiate with fly cli
 5.7.1-flyenv
 
-$ fly --version # for commands without a target it fallback to use the cli downloaed initially 
+$ fly --version # for commands without a target it fallback to use the cli downloaed initially
 6.0.0-flyenv
 ```
 
@@ -33,15 +33,19 @@ When you use the command with the specific target, it fetches the concourse vers
 corresponding fly version is already installed under `$HOME/.flyenv/<version>/fly`. If not it downloads the fly cli
 from the target and put it to the directory above.
 
+# Skip SSL Validation
+
+Sometimes you may have Concourse targets that don't have valid certificates. You can tell flyenv to skip SSL validation by setting the `FLYENV_SKIP_SSL` environment variable before running `fly` commands.
+
 # Installation
 
 Download the binary from release.
 
-## Recommended: 
-override the fly installed with the flyenv binary to have a more transparent experience. 
+## Recommended:
+override the fly installed with the flyenv binary to have a more transparent experience.
 
 # Install from source
- 
+
 1. clone the repo
 1. go mod download
 1. go build

--- a/main.go
+++ b/main.go
@@ -5,10 +5,9 @@ import (
 	"archive/zip"
 	"bytes"
 	"compress/gzip"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"github.com/concourse/concourse/fly/rc"
-	"github.com/jessevdk/go-flags"
 	"io"
 	"io/ioutil"
 	"log"
@@ -18,6 +17,9 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/concourse/concourse/fly/rc"
+	"github.com/jessevdk/go-flags"
 )
 
 type Command struct {
@@ -138,6 +140,12 @@ func getFlyCliFromTarget(target string, targetFolder string) {
 		downloadUrl = downloadUrl + runtime.GOOS
 	default:
 		log.Fatal(runtime.GOOS, " is not supported")
+	}
+
+	_, skipSSL := os.LookupEnv("FLYENV_SKIP_SSL")
+	if skipSSL {
+		log.Println("FLYENV_SKIP_SSL variable set: skippling SSL validation")
+		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
 
 	log.Println("download cli from:", downloadUrl)


### PR DESCRIPTION
This is great tool. Thanks for making it!

I tried using this with a Concourse deployment that has an invalid cert (yay enterprise!) and it kept failing to download the fly binary from the target because of cert errors.

I didn't want to blanket disable SSL validation. Because of how flyenv is run I thought an optional environment variable made sense.

So now if `FLYENV_SSL_SKIP` is set in your environment it will not check SSL validity when downloading the binary.

Before:
```sh
$ fly -t azure login -k
  2020/04/30 15:42:52 download cli from: https://my-concourse/api/v1/cli?arch=amd64&platform=darwin
  2020/04/30 15:42:52 error downloading fly cliGet https://my-concourse/api/v1/cli?arch=amd64&platform=darwin: x509: cannot validate certificate for my-concourse because it doesn't contain any IP SANs
```

After:
```sh
$ export FLYENV_SKIP_SSL=1
$ fly -t azure login -k
  2020/04/30 15:57:30 FLYENV_SKIP_SSL variable set: skippling SSL validation
  2020/04/30 15:57:30 download cli from: https://my-concourse/api/v1/cliarch=amd64&platform=darwin
  logging in to team 'main'

  navigate to the following URL in your browser:
```